### PR TITLE
fix nested link

### DIFF
--- a/script.js
+++ b/script.js
@@ -38,6 +38,6 @@ function insertStatusIcon(el) {
 
         /* And finally insert the elements into the DOM. */
         link.appendChild(img);
-        el.appendChild(link);
+        el.parentNode.insertBefore(link, el.nextSibling);
     }
 }


### PR DESCRIPTION
currently, the travis-img link only works if you ctrl+click (open in new tab), otherwise the parent link (the repository's link) takes priority

this fix should place the travis-img link next to the repo's link, instead of nesting it
