### PR TITLE
show status of master instead of latest build

### DIFF
--- a/script.js
+++ b/script.js
@@ -31,7 +31,7 @@ function insertStatusIcon(el) {
     var project = el.pathname;
 
     var img = window.document.createElement('img');
-    img.src = 'https://api.travis-ci.org' + project + '.svg';
+    img.src = 'https://api.travis-ci.org' + project + '.svg?branch=master';
     img.alt = 'build status';
 
 


### PR DESCRIPTION
hey, so, when I am working with branches and one of those branches fails I get a red icon despite my master branch still being all good.

so... this PR is more of a question, do you want to show the 'most recent build' or the 'current state of master', I think ideally it would show the 'status of the branch you're looking at', but since I CBF writing the vanilla js to figure out if/which branch the user is on I settled for this instead.

thoughts?
